### PR TITLE
Check admin expenses view for currency distinction

### DIFF
--- a/public/admin/expenses/view.php
+++ b/public/admin/expenses/view.php
@@ -75,7 +75,7 @@ if (!$expense) {
                                 <span class="badge badge-info"><?php echo ucfirst(str_replace('_', ' ', $expense['category'])); ?></span>
                             </p>
                             <p><strong><?php echo __('amount'); ?>:</strong> 
-                                <span class="text-danger h5"><?php echo formatCurrency($expense['amount'], $expense['currency'] ?? 'USD'); ?></span>
+                                <span class="text-danger h5"><?php echo formatCurrencyAmount($expense['amount'], $expense['currency'] ?? 'USD'); ?></span>
                             </p>
                             <p><strong><?php echo __('expense_date'); ?>:</strong> <?php echo date('M j, Y', strtotime($expense['expense_date'])); ?></p>
                         </div>
@@ -84,7 +84,7 @@ if (!$expense) {
                             <?php if ($expense['reference_number']): ?>
                             <p><strong><?php echo __('reference_number'); ?>:</strong> <?php echo htmlspecialchars($expense['reference_number']); ?></p>
                             <?php endif; ?>
-                            <p><strong><?php echo __('currency'); ?>:</strong> <?php echo strtoupper($expense['currency'] ?? 'USD'); ?></p>
+                            <p><strong><?php echo __('currency'); ?>:</strong> <?php echo getCurrencyDisplay($expense['currency'] ?? 'USD'); ?></p>
                         </div>
                     </div>
 
@@ -116,7 +116,7 @@ if (!$expense) {
                 <div class="card-body">
                     <div class="mb-3">
                         <h6 class="text-primary"><?php echo __('total_amount'); ?></h6>
-                        <h4 class="text-danger"><?php echo formatCurrency($expense['amount'], $expense['currency'] ?? 'USD'); ?></h4>
+                        <h4 class="text-danger"><?php echo formatCurrencyAmount($expense['amount'], $expense['currency'] ?? 'USD'); ?></h4>
                     </div>
                     
                     <div class="mb-3">


### PR DESCRIPTION
Add currency distinction to `admin/expenses/view.php` to display amounts and currencies correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bf78752-2b99-4290-a03e-d799f00c43f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bf78752-2b99-4290-a03e-d799f00c43f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

